### PR TITLE
latest v2 version in migration readme

### DIFF
--- a/docs/MIGRATE.md
+++ b/docs/MIGRATE.md
@@ -7,7 +7,7 @@ $ cd {{PROJECT}}
 $ cstore pull
 $ mv cstore.yml cstore.yml.v1
 $ mv  /usr/local/bin/cstore /usr/local/bin/cstore-v1 
-$ sudo curl -L -o  /usr/local/bin/cstore https://github.com/turnerlabs/cstore/releases/download/v2.0.0-alpha/cstore_darwin_amd64 && sudo chmod +x /usr/local/bin/cstore
+$ sudo curl -L -o /usr/local/bin/cstore https://github.com/turnerlabs/cstore/releases/download/v2.5.1-alpha/cstore_darwin_amd64 && sudo chmod +x /usr/local/bin/cstore
 $ cstore push // files pulled from old version of cStore
 ```
 


### PR DESCRIPTION
Updating v1 -> v2 migration docs to include latest v2 release. Downloading older miner release results in slightly different `yml`.